### PR TITLE
Update docs.mdx

### DIFF
--- a/src/content/docs/docs.mdx
+++ b/src/content/docs/docs.mdx
@@ -131,5 +131,6 @@ sudo systemctl status sddm
 This will show the status of the sddm service, when it started, if any errors occurred while it was executing.
 
 For a far more complete list of what all these two tools can do read:
+
 [http://0pointer.de/blog/projects/journalctl.html](http://0pointer.de/blog/projects/journalctl.html)\
-[http://www.freedesktop.org/wiki/Software/systemd/TipsAndTricks/](http://www.freedesktop.org/wiki/Software/systemd/TipsAndTricks/)
+[https://systemd.io/TIPS_AND_TRICKS/](https://systemd.io/TIPS_AND_TRICKS/)


### PR DESCRIPTION
Change URL because on https://www.freedesktop.org/wiki/Software/systemd/TipsAndTricks/ are obsoleted.

Find in the old url :
This page has been obsoleted and replaced: https://systemd.io/TIPS_AND_TRICKS.